### PR TITLE
Add missing style for strike-through formatting

### DIFF
--- a/public/css/extra.css
+++ b/public/css/extra.css
@@ -365,3 +365,5 @@ small .dropdown a:focus, small .dropdown a:hover {
         font-size: 12px !important;
     }
 }
+
+.line-through{text-decoration:line-through}


### PR DESCRIPTION
Asciidoctor.js realizes the strikethrough via a style. This PR adds such style to the stylesheet.